### PR TITLE
Fix migration error

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,9 @@
 ForeverFamilyFoundation::Application.routes.draw do
 
-  ActiveAdmin.routes(self)
+  begin
+    ActiveAdmin.routes(self)
+  rescue ActiveRecord::StatementInvalid => e
+  end
 
   devise_for :admin_users, ActiveAdmin::Devise.config
 


### PR DESCRIPTION
Error caused by active admin trying to load all models immediately where
model does not exist in the database see:
https://github.com/gregbell/active_admin/issues/783#issuecomment-4106752
