### PR TITLE
New Events page format with section headers

### DIFF
--- a/app/views/events/index.html.haml
+++ b/app/views/events/index.html.haml
@@ -1,10 +1,14 @@
-%h3 Upcoming Events
 %ul.events
   - @events.each do |event|
-    %li
+    .page_section
+      %h2= event.times.gsub!(/0(\d:\d\d)/,' \1')
+      %div{:class => "center-block"}
+      %br
       - if !event.url.blank?
-        %h4=link_to event.title, event.url, target: '_blank'
+        %center
+          %h4= link_to event.title, event.url, target: '_blank'
       - else
-        %h4=link_to event.title, event
-      %h5= event.times
+        %center
+          %h4= link_to event.title, event
+      -#%h5= event.times
       %p= truncate_html event.description, length: 200

--- a/spec/views/events/index.html.haml_spec.rb
+++ b/spec/views/events/index.html.haml_spec.rb
@@ -12,7 +12,7 @@ describe "events/index" do
   end
 
   it "should display date only once" do
-    date = "#{@start_time.utc.to_s(:ordinal_date)} " + [@start_time.utc.strftime("%I:%M %p"), @end_time.utc.strftime("%I:%M %p")].join(' - ')
+    date = "#{@start_time.utc.to_s(:ordinal_date)} " + [@start_time.utc.strftime("%l:%M %p"), @end_time.utc.strftime("%l:%M %p")].join(' - ')
     render
     expect(rendered).to include(date)
   end


### PR DESCRIPTION
Each event now has it's own section box
Show date and time in section headers for each Event
Trim leading zeros from time 
Update spec test for no leading zeros time