### PR TITLE
Better handling of pics in Events

### DIFF
--- a/app/admin/events.rb
+++ b/app/admin/events.rb
@@ -25,6 +25,7 @@ ActiveAdmin.register Event do
     f.inputs 'Details' do
       f.input :title
       f.input :url
+      f.input :pic_link
       f.input :description
       f.input :start_time
       f.input :end_time

--- a/app/assets/stylesheets/partials/_layout.scss
+++ b/app/assets/stylesheets/partials/_layout.scss
@@ -23,6 +23,12 @@ body {
   }
 }
 
+.event_pic {
+  float: left;
+  max-width: 20em;
+  max-height: 20em;
+}
+
 .float-left {
   float: left;
 }

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -4,12 +4,12 @@ class Event < ActiveRecord::Base
   validates_presence_of :end_time
   validates_presence_of :title
 
-  attr_accessible :start_time, :end_time, :title, :description, :url
+  attr_accessible :start_time, :end_time, :title, :description, :url, :pic_link
 
   scope :upcoming, -> { where("start_time >= ?", Time.now).order('start_time asc').limit(4) }
   scope :all_upcoming, -> { where("start_time >= ?", Time.now).order('start_time asc') }
 
-  attr_accessible :title, :url, :description, :start_time, :end_time
+  attr_accessible :title, :url, :pic_link, :description, :start_time, :end_time
 
   def times
     if start_time.day == end_time.day

--- a/app/views/events/index.html.haml
+++ b/app/views/events/index.html.haml
@@ -2,12 +2,16 @@
   - @events.each do |event|
     .page_section
       %h2= event.times
-      %div{:class => "center-block"}
-      - if !event.url.blank?
-        %center
-          %h4= link_to event.title, event.url, target: '_blank'
-      - else
-        %center
-          %h4= link_to event.title, event
-      -#%h5= event.times
-      %p= truncate_html event.description, length: 200
+      
+      - if !event.pic_link.blank?
+        .event_pic
+          %a= image_tag(event.pic_link, width: "90em")
+      %div{:class => "inline-block"}
+        - if !event.url.blank?
+          %center
+            %h4= link_to event.title, event.url, target: '_blank'
+        - else
+          %center
+            %h4= link_to event.title, event
+        -#%h5= event.times
+        %p= truncate_html event.description, length: 200

--- a/db/migrate/20160327055044_add_pic_link_to_events.rb
+++ b/db/migrate/20160327055044_add_pic_link_to_events.rb
@@ -1,0 +1,5 @@
+class AddPicLinkToEvents < ActiveRecord::Migration
+  def change
+    add_column :events, :pic_link, :string
+  end
+end


### PR DESCRIPTION
Added pic_link column to Events table
Can enter pic_link as separate field is appropriate
Set thumbnail size at 90em
Thumbnail in upper left corner of .page_section, text flows around it now