### PR TITLE
Attach files, Users export

### DIFF
--- a/app/models/address.rb
+++ b/app/models/address.rb
@@ -6,6 +6,6 @@ class Address < ActiveRecord::Base
   attr_accessible :address, :city, :state, :zip, :country
 
   def to_s
-    "#{address} #{city}, #{state} #{zip} #{country}"
+    "#{address}, #{city}, #{state}, #{zip}, #{country}"
   end
 end

--- a/app/models/attached_file.rb
+++ b/app/models/attached_file.rb
@@ -24,9 +24,27 @@ class AttachedFile < ActiveRecord::Base
   before_save :set_content_type
 
   #
-  # ensure the content-type on S3 is correct, there has been some problems with it in FFF usage
+  # explicitly set some content_type using file extension
+  # if not one of the explicits, then default to what paperclip thinks it is
   #
   def set_content_type
+    extension = File.extname(attachment_file_name).downcase
+    case extension
+      when '.pdf'
+        self.attachment_content_type = 'application/pdf'
+      when '.txt', ''
+        self.attachment_content_type = 'text/plain'
+      when '.csv.'
+        self.attachment_content_type = 'text/csv'
+      when '.jpg'
+        self.attachment_content_type = 'image/jpeg'
+      when '.png'
+        self.attachment_content_type = 'image/png'
+      when '.xml'
+        self.attachment_content_type = 'text/xml'
+      when '.bmp'
+        self.attachment_content_type = 'image/bmp'
+    end
     self.attachment.options.merge!(s3_headers: {
                                     'Content-Type' => self.attachment_content_type || 'text/plain'
                                     })

--- a/config/application.rb
+++ b/config/application.rb
@@ -1,5 +1,6 @@
 require File.expand_path('../boot', __FILE__)
 
+require 'csv'
 require 'rails/all'
 
 


### PR DESCRIPTION
Attached files use content_type from file extension
Users export add commas to address
application.rd add 'require csv'