### PR TITLE
Postgres upgrade, checkbox removal from sitterform admin

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,7 @@ ruby '2.3.3'
 gem 'protected_attributes'
 
 gem 'rails', '~> 4.2.5'
-gem 'pg', '~> 0.18.4'
+gem 'pg', '~> 0.20.0'
 gem 'puma'
 # Gems used only for assets and not required
 # in production environments by default.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -361,7 +361,7 @@ GEM
       cocaine (~> 0.5.5)
       mime-types
       mimemagic (~> 0.3.0)
-    pg (0.18.4)
+    pg (0.20.0)
     poltergeist (1.8.1)
       capybara (~> 2.1)
       cliver (~> 0.3.1)
@@ -575,7 +575,7 @@ DEPENDENCIES
   newrelic_rpm (~> 3.13)
   non-stupid-digest-assets
   paperclip (= 5.1.0)
-  pg (~> 0.18.4)
+  pg (~> 0.20.0)
   poltergeist (~> 1.8.1)
   protected_attributes
   pry

--- a/app/admin/sitterforms.rb
+++ b/app/admin/sitterforms.rb
@@ -28,14 +28,11 @@ ActiveAdmin.register Sitterform do
       row :youtube
       row :blog
       row :related_contact_info
-      row :been_to_medium
-      row :related_contact_info
       row :belief_type
-      row :lost_loved_one
       row :signature
       row :signature_checkbox
       table_for sitter.known_deads do
-        column "Known Deceaseds" do |f|
+        column "Lost Loved Ones" do |f|
           "Name: " + f.name + "   relationship: " + f.relationship.name
         end
       end

--- a/app/admin/users.rb
+++ b/app/admin/users.rb
@@ -168,7 +168,7 @@ ActiveAdmin.register User do
       f.input :home_phone
       f.input :work_phone
       f.input :fax
-      f.input :sitter_registration
+      f.input :sitter_registration, as: :boolean
       f.input :is_business do |user|
         user.business.present?
       end

--- a/app/models/sitterform.rb
+++ b/app/models/sitterform.rb
@@ -7,7 +7,9 @@ class Sitterform < ActiveRecord::Base
 
   has_many :relationships, through: :known_deads
 
-  validates :user_id, presence: true
+  validates_presence_of :belief_type_id
+  validates_presence_of :user_id
+  validate :relationship_and_date
   validate :signature_and_checkbox # see below custom validation
 
   attr_accessible :user_id, :phone, :alt_email, :cell, :website, :facebook, :pinterest, :instagram
@@ -21,6 +23,21 @@ class Sitterform < ActiveRecord::Base
       if !self.signature.empty?
         if !self.signature_checkbox
           self.errors.add(:signature_checkbox, 'needs to be checked')
+        end
+      end
+    end
+
+    def relationship_and_date
+      self.known_deads.each do |d|
+        if !d[:name].blank?
+          if d[:relationship_id] == 1
+            self.errors.add(:relationship, 'needs to be selected for ' + d[:name])
+          end
+          if d[:year_of_death].empty?
+            self.errors.add(:year_of_death, 'needs to be filled in for ' + d[:name])
+          elsif (d[:yesr_of_death].to_i < 1900 || d[:year_of_death].to_i > 2017)
+            self.errors.add(:year_of_death, 'invalid for ' + d[:name])
+          end
         end
       end
     end


### PR DESCRIPTION
Upgrade pg gem for Postgres upgrade from 9.3 ->9.6
remove Medium and Lost Loved One checkboxes from Sitterform Admin

closes #198 